### PR TITLE
Add fastcpd package to Change Point Detection section.

### DIFF
--- a/TimeSeries.md
+++ b/TimeSeries.md
@@ -319,7 +319,9 @@ submitting an issue or pull request in the GitHub repository linked above.
   `r pkg("VARDetect")` implements multiple change point detection in structural VAR models.
   `r pkg("Rbeast")` provides Bayesian change-point detection and time series decomposition.
   `r pkg("breakfast")` includes methods for fast multiple
-  change-point detection and estimation.
+  change-point detection and estimation. `r pkg("fastcpd")` provides flexible
+  and fast change point detection for regression type data, time series (ARIMA, VAR and GARCH) and
+  any other data with a custom cost function using Sequential Gradient Descent with PELT.
 - Tests for possibly non-monotonic trends are provided by
   `r pkg("funtimes")`.
 - *Time series imputation* is provided by the


### PR DESCRIPTION
It seems that Change Point Detection only exists in `Forecasting and Univariate Modeling`.

[fastcpd](https://fastcpd.xingchi.li) can handle not only univariate data but also regression type data and any other data as long as a cost function can be provided. I have put it in this section for now but please feel free to let me know if another or a new section is more appropriate. Thank you.