### PR TITLE
Inclusion of two packages and small edit

### DIFF
--- a/TimeSeries.md
+++ b/TimeSeries.md
@@ -603,7 +603,7 @@ submitting an issue or pull request in the GitHub repository linked above.
   Another implementation with bootstrapped prediction intervals is given in `r pkg("VAR.etp")`.
   `r pkg("bvartools")` assists in the set-up of Bayesian VAR models, while
   `r pkg("bsvars")` and `r pkg("bayesianVARs")` include efficient algorithms for estimating Bayesian models.
-  `r pkg("BVAR")` provides a toolkit for hierarchical Bayesian VAR models.
+  `r pkg("BVAR")` and `r pkg("bayesianVARs")` provide toolkits for hierarchical Bayesian VAR models.
   `r pkg("BMTAR")` and `r pkg("mtarm")` implement Bayesian Multivariate Threshold AR models.
   Factor-augmented VAR (FAVAR) models are estimated by a Bayesian method with `r pkg("FAVAR")`.
   `r pkg("BGVAR")` implements Bayesian Global VAR models.

--- a/TimeSeries.md
+++ b/TimeSeries.md
@@ -601,9 +601,8 @@ submitting an issue or pull request in the GitHub repository linked above.
   Shrinkage estimation methods for VARs are implemented in `r pkg("VARshrink")`.
   More elaborate models are provided in package `r pkg("vars")` and `r pkg("tsDyn")`.
   Another implementation with bootstrapped prediction intervals is given in `r pkg("VAR.etp")`.
-  `r pkg("bvartools")` assists in the set-up of Bayesian VAR models, while
-  `r pkg("bsvars")` and `r pkg("bayesianVARs")` include efficient algorithms for estimating Bayesian models.
-  `r pkg("BVAR")` and `r pkg("bayesianVARs")` provide toolkits for hierarchical Bayesian VAR models.
+  `r pkg("bvartools")` assists in the set-up of Bayesian VAR models, while `r pkg("BVAR")` and `r pkg("bayesianVARs")` provide toolkits for hierarchical Bayesian VAR models.
+  `r pkg("bsvars")`, `r pkg("bsvarSIGNs")`, and `r pkg("bvarsv")` include efficient algorithms for estimating Bayesian Structural VAR models.
   `r pkg("BMTAR")` and `r pkg("mtarm")` implement Bayesian Multivariate Threshold AR models.
   Factor-augmented VAR (FAVAR) models are estimated by a Bayesian method with `r pkg("FAVAR")`.
   `r pkg("BGVAR")` implements Bayesian Global VAR models.


### PR DESCRIPTION
Hi Dear @robjhyndman and @rkillick 

How are you? I am well and at the occassion of premiering our new **bsvarSIGNs** package on CRAN, I let myself submit this PR to update this article. The changes I propose are as follows:

- reedited a sentence with packages **bvartools**, **BVAR**, and **bayesianVARs** putting them together. This really makes sense as all of these work with Reduced-Form VARs, while the latter two are still distinguished due to their focus on hierarchical modelling.
- created a separate sentence for Bayesian Structural VAR models with packages **bsvars**, **bsvarSIGNs** (the new one), and **bvarsv**. This makes sense bc users are more likely to look for packages specifically covering SVARs.

I hope that edits will be to your liking. Thank for your consideration.

Greetings, Tomasz @donotdespair